### PR TITLE
Fix: This string use the esc_html() function and are not translated

### DIFF
--- a/templates/admin/dashboard-analytics.php
+++ b/templates/admin/dashboard-analytics.php
@@ -136,7 +136,7 @@ $disable_btn = count( $unuse_widget ) == count( array_intersect( $unuse_widget, 
 									<span class="enabled" title="Enabled"></span>
 								<?php endif;?>
 							</div>
-							<span class="ha-dashboard-analytics__item-total-count"><?php echo esc_html('total use: 0');?></span>
+							<span class="ha-dashboard-analytics__item-total-count"><?php echo esc_html__('total use: 0', 'happy-elementor-addons' );?></span>
 						</div>
 					</fieldset>
 				</div>

--- a/widgets/news-ticker/widget.php
+++ b/widgets/news-ticker/widget.php
@@ -476,7 +476,7 @@ class News_Ticker extends Base {
 
 		$settings = $this->get_settings_for_display();
 		if ( empty( $settings['selected_posts'] ) ) { ?>
-			<div style="margin: 1rem;padding: 1rem 1.25rem;border-left: 5px solid #f5c848;color: #856404;background-color: #fff3cd;"><?php echo esc_html('Plese select news ticker posts.', 'happy-elementor-addons'); ?></div>
+			<div style="margin: 1rem;padding: 1rem 1.25rem;border-left: 5px solid #f5c848;color: #856404;background-color: #fff3cd;"><?php echo esc_html__('Please select news ticker posts.', 'happy-elementor-addons'); ?></div>
 		<?php }
 
 		$query_args = [


### PR DESCRIPTION
Fix: [This string use the esc_html() function and are not translated](https://wordpress.org/support/topic/this-string-use-the-esc_html-function-and-are-not-translated-11/)